### PR TITLE
Fix default options issue

### DIFF
--- a/owl.rows.js
+++ b/owl.rows.js
@@ -5,7 +5,7 @@
 ;(function ($, window, document, undefined) {
     Owl2row = function (scope) {
         this.owl = scope;
-        this.owl.options = $.extend(Owl2row.Defaults, this.owl.options);
+        this.owl.options = $.extend({}, Owl2row.Defaults, this.owl.options);
         //link callback events with owl carousel here
 
         this.handlers = {


### PR DESCRIPTION
Without this fix, defaults parameters are overriden. So if there are two or more owl carousel on the page, the second inherits plugin options from the first.
(owl2 documentation mistake)
